### PR TITLE
Extend evidence-driven-testing: headless capture and non-UI evidence

### DIFF
--- a/evidence-driven-testing/SKILL.md
+++ b/evidence-driven-testing/SKILL.md
@@ -117,8 +117,10 @@ swap the recorder for scripted capture:
 ## Capture hygiene
 
 - Confirm the server you're probing is running *your* code (right port,
-  right process — `lsof -i :<port>`), especially when multiple agents share
-  a machine.
+  right process), especially when multiple agents share a machine:
+  `lsof -i :<port>` — or where `lsof` isn't installed,
+  `ss -ltnp "sport = :<port>"` to find the listener's PID, then
+  `ps -p <pid> -o args=` to confirm it's yours.
 - Evidence complements the repo's checks (typecheck/build/tests); it never
   replaces them.
 - Hand before/after media pairs to a before/after tool for the PR embed

--- a/evidence-driven-testing/SKILL.md
+++ b/evidence-driven-testing/SKILL.md
@@ -72,9 +72,31 @@ swap the recorder for scripted capture:
   captures URLs or elements and its pairs feed PR embeds directly. In
   containers/VMs where Chrome fails with "No usable sandbox", set
   `AGENT_BROWSER_ARGS="--no-sandbox"`.
-- **Video / multi-step flows**: a one-off Playwright script via npx
-  (`recordVideo` on the browser context); trim or compress with ffmpeg if
-  large. Don't add playwright to the project's dependencies for this.
+- **Video / multi-step flows**: a one-off Playwright script, run without
+  adding playwright to the project's dependencies:
+
+  ```bash
+  npx --yes --package=playwright node record.mjs
+  ```
+
+  (Plain `npx playwright node record.mjs` fails — `node` is not a Playwright
+  CLI command; `--package=playwright` is what puts the module on the path.)
+  Minimal `record.mjs`:
+
+  ```js
+  import { chromium } from "playwright";
+  const browser = await chromium.launch();
+  const context = await browser.newContext({
+    recordVideo: { dir: ".artifacts/<task-name>/" },
+  });
+  const page = await context.newPage();
+  await page.goto("http://localhost:3000/path-under-test");
+  // ...drive the flow, one meaningful state change per step...
+  await context.close(); // finalizes the .webm
+  await browser.close();
+  ```
+
+  Trim or compress with ffmpeg if the file is large.
 - **The annotation protocol becomes files**: number captures in test order
   with the assertion in the name — `01-precondition-signed-in.png`,
   `02-it-saves-on-blur-passed.png` — and keep an `assertions.md` in the

--- a/evidence-driven-testing/SKILL.md
+++ b/evidence-driven-testing/SKILL.md
@@ -3,16 +3,17 @@ name: evidence-driven-testing
 description: >
   Records visual proof while testing UI behavior — screen recording with structured
   test/assertion annotations — then posts the video and a results summary to the PR
-  and tracker issue. Use whenever a UI change needs verifiable evidence that it works,
-  instead of prose claims.
-compatibility: Requires a GUI environment with screen recording, an authenticated browser session for the app under test, and gh (GitHub CLI) or equivalent for posting evidence.
+  and tracker issue. Use whenever a change needs verifiable evidence that it works,
+  instead of prose claims — including headless environments (scripted screenshots
+  and probes) and non-UI changes (measured numbers, output pairs).
+compatibility: Screen-recording path requires a GUI environment and an authenticated browser session for the app under test; the headless path requires only a running app and a scriptable browser (e.g. Playwright via npx). Posting evidence requires gh (GitHub CLI) or equivalent.
 metadata:
   version: "1.0"
 ---
 
 # Evidence-Driven Testing
 
-Record annotated screen-recording proof of UI behavior, then attach it to the PR and tracker issue.
+Record annotated proof of behavior, then attach it to the PR and tracker issue.
 
 ## Inputs
 
@@ -58,3 +59,45 @@ Record annotated screen-recording proof of UI behavior, then attach it to the PR
 - Never record a half-covered or tiled window — maximize first.
 - When verifying a fix, show or reference the old failure alongside the new success.
 - Always state the exact commit/branch/deployment tested against.
+
+## Headless path (no GUI available)
+
+When the agent has no desktop to record, keep the same assertion discipline;
+swap the recorder for scripted capture:
+
+- Save everything to `.artifacts/<task-name>/` (gitignore it — evidence gets
+  uploaded, never committed). Keep the capture script beside the captures so
+  the run is repeatable.
+- **Screenshots**: the `before-and-after` CLI (`@vercel/before-and-after`)
+  captures URLs or elements and its pairs feed PR embeds directly. In
+  containers/VMs where Chrome fails with "No usable sandbox", set
+  `AGENT_BROWSER_ARGS="--no-sandbox"`.
+- **Video / multi-step flows**: a one-off Playwright script via npx
+  (`recordVideo` on the browser context); trim or compress with ffmpeg if
+  large. Don't add playwright to the project's dependencies for this.
+- **The annotation protocol becomes files**: number captures in test order
+  with the assertion in the name — `01-precondition-signed-in.png`,
+  `02-it-saves-on-blur-passed.png` — and keep an `assertions.md` in the
+  artifacts folder listing each `test_start` / `assertion` with its result
+  (`passed` / `failed` / `untested` + reason).
+
+## Non-UI changes still need evidence
+
+- **API / performance**: a scripted probe with measured numbers — request
+  counts per phase, latency before/after — captured to `probe-output.txt`.
+- **Rendering / canvas / shader**: rendered frames plus pixel assertions
+  (diff values), reviewed by eye and saved as PNGs.
+- **Agent behavior**: the relevant transcript excerpt showing the tool call
+  and response.
+- **Bug fixes**: reproduce and capture the failure **before** writing the
+  fix — that capture is the "before" half of a before/after pair.
+
+## Capture hygiene
+
+- Confirm the server you're probing is running *your* code (right port,
+  right process — `lsof -i :<port>`), especially when multiple agents share
+  a machine.
+- Evidence complements the repo's checks (typecheck/build/tests); it never
+  replaces them.
+- Hand before/after media pairs to a before/after tool for the PR embed
+  (e.g. `before-and-after before.png after.png --markdown`).


### PR DESCRIPTION
## What changed

Extends the skill beyond GUI screen recording, keeping the existing annotation discipline intact:

- **Headless path** — for agents with no desktop: scripted screenshot pairs via the `@vercel/before-and-after` CLI (with the `AGENT_BROWSER_ARGS="--no-sandbox"` container workaround), one-off Playwright `recordVideo` for flows, and a file-naming + `assertions.md` convention that carries the `test_start` / `assertion` protocol into artifacts.
- **Non-UI evidence** — API/perf probes with measured numbers, rendered-frame pixel assertions, agent transcript excerpts, and reproduce-the-failure-first for bug fixes.
- **Capture hygiene** — verify the probed server runs your code, evidence complements (never replaces) the repo checks, and pairs feed a before/after tool for the PR embed.
- Frontmatter description/compatibility extended to match; the original GUI recording sections are unchanged.

## Heads-up: overlaps with feat/executable-evidence-testing

The local `feat/executable-evidence-testing` rework (FFmpeg/X11 recorder with burned-in annotations, `evidence.py`, tests) rewrites this same file. The two are complementary — that rework requires an X11 display; this covers display-less environments and non-visual changes. Suggested order: land the rework first, then graft these three sections onto it (they're self-contained and append cleanly). This PR exists so the content is reviewable now rather than parked.

## How it was tested

Content-only change. The headless capture commands were verified end-to-end in a downstream repo (boringcomputers/ruth): real `before-and-after` captures of local pages, including the no-sandbox workaround on Linux.

Made with [Cursor](https://cursor.com)