### PR TITLE
greploop: make the iteration cap an input, default 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Use it whenever a change needs verifiable evidence that it works, instead of pro
 
 ### [greploop](greploop/SKILL.md)
 
-Iteratively fixes a PR (GitHub), MR (GitLab), or shelved changelist (Perforce) until Greptile gives a perfect review: 5/5 confidence with zero unresolved comments. Triggers the review, fixes actionable comments, resolves threads, pushes, and repeats (max 5 iterations).
+Iteratively fixes a PR (GitHub), MR (GitLab), or shelved changelist (Perforce) until Greptile gives a perfect review: 5/5 confidence with zero unresolved comments. Triggers the review, fixes actionable comments, resolves threads, pushes, and repeats, up to `--max-iterations` cycles (default 10).
 
 Use it when a PR should be fully optimized against Greptile's code review standards before merge.
 

--- a/greploop-apps/SKILL.md
+++ b/greploop-apps/SKILL.md
@@ -21,6 +21,7 @@ Iteratively fix a PR/MR/CL until Greptile gives a perfect review: 5/5 confidence
 ## Inputs
 
 - **PR/MR/CL number** (optional): If not provided, detect the PR/MR for the current branch, or the default pending changelist for p4.
+- **`--max-iterations N`** (optional, default **10**): cap on review-fix-push cycles before the loop stops and reports the current state. Raise it for large PRs where Greptile keeps surfacing new findings; lower it to bound cost.
 
 ## Instructions
 
@@ -76,7 +77,7 @@ Key field differences:
 
 ### 2. Loop
 
-Repeat the following cycle. **Max 5 iterations** to avoid runaway loops.
+Repeat the following cycle at most **`--max-iterations`** times (default **10**) to avoid runaway loops.
 
 #### A. Trigger Greptile review
 
@@ -326,7 +327,7 @@ Filter to comments from the Greptile bot user that have not been marked as resol
 Stop the loop if **any** of these are true:
 
 - Confidence score is **5/5** AND there are **zero unresolved comments**
-- Max iterations reached (report current state)
+- `--max-iterations` reached (report current state)
 
 #### D. Fix actionable comments
 
@@ -438,7 +439,7 @@ Greploop complete.
 If not fully resolved:
 
 ```
-Greploop stopped after 5 iterations.
+Greploop stopped after 10 iterations (--max-iterations).
   Platform:      GitLab
   Confidence:    4/5
   Resolved:      12 comments

--- a/greploop-apps/SKILL.md
+++ b/greploop-apps/SKILL.md
@@ -436,10 +436,10 @@ Greploop complete.
   Remaining:     0
 ```
 
-If not fully resolved:
+If not fully resolved (`<N>` is the effective cap — the `--max-iterations` value supplied, or 10 by default):
 
 ```
-Greploop stopped after 10 iterations (--max-iterations).
+Greploop stopped after <N> iterations (--max-iterations <N>).
   Platform:      GitLab
   Confidence:    4/5
   Resolved:      12 comments

--- a/greploop/SKILL.md
+++ b/greploop/SKILL.md
@@ -428,10 +428,10 @@ Greploop complete.
   Remaining:     0
 ```
 
-If not fully resolved:
+If not fully resolved (`<N>` is the effective cap — the `--max-iterations` value supplied, or 10 by default):
 
 ```
-Greploop stopped after 10 iterations (--max-iterations).
+Greploop stopped after <N> iterations (--max-iterations <N>).
   Platform:      GitLab
   Confidence:    4/5
   Resolved:      12 comments

--- a/greploop/SKILL.md
+++ b/greploop/SKILL.md
@@ -20,6 +20,7 @@ Iteratively fix a PR/MR/CL until Greptile gives a perfect review: 5/5 confidence
 ## Inputs
 
 - **PR/MR/CL number** (optional): If not provided, detect the PR/MR for the current branch, or the default pending changelist for p4.
+- **`--max-iterations N`** (optional, default **10**): cap on review-fix-push cycles before the loop stops and reports the current state. Raise it for large PRs where Greptile keeps surfacing new findings; lower it to bound cost.
 
 ## Instructions
 
@@ -75,7 +76,7 @@ Key field differences:
 
 ### 2. Loop
 
-Repeat the following cycle. **Max 5 iterations** to avoid runaway loops.
+Repeat the following cycle at most **`--max-iterations`** times (default **10**) to avoid runaway loops.
 
 #### A. Trigger Greptile review
 
@@ -318,7 +319,7 @@ Filter to comments from the Greptile bot user that have not been marked as resol
 Stop the loop if **any** of these are true:
 
 - Confidence score is **5/5** AND there are **zero unresolved comments**
-- Max iterations reached (report current state)
+- `--max-iterations` reached (report current state)
 
 #### D. Fix actionable comments
 
@@ -430,7 +431,7 @@ Greploop complete.
 If not fully resolved:
 
 ```
-Greploop stopped after 5 iterations.
+Greploop stopped after 10 iterations (--max-iterations).
   Platform:      GitLab
   Confidence:    4/5
   Resolved:      12 comments


### PR DESCRIPTION
## What changed

Both `greploop` and `greploop-apps` hard-coded **Max 5 iterations**. PR #5 needed exactly five review-fix-push cycles to reach 5/5, so one more finding would have stopped the loop short of the goal.

The cap is now an input:

- `--max-iterations N` (optional, default **10**) documented in the Inputs section of both variants
- the loop instruction, exit condition, and "stopped after N iterations" report example reference it
- README updated to match

No behaviour change beyond the default and the ability to override it.

## How it was tested

Documentation-only change. Verified with `grep -n max-iterations` that all four references in each SKILL.md are consistent, and that `greploop` and `greploop-apps` stay in lockstep (identical hunks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WUy5mRbtePi7Ks2BuFQX5S
