### PR TITLE
unslop: vendor the pstack skill and wire it into AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,4 +95,4 @@ infrastructure (stubs, fixtures), and anything that can't be tested locally.
 | `before-and-after` | this repo, vendored from [vercel-labs/before-and-after](https://github.com/vercel-labs/before-and-after) (or `npx skills add vercel-labs/before-and-after`) |
 | `greploop` | this repo, vendored from [greptileai/skills](https://github.com/greptileai/skills) |
 | `greploop-apps` | this repo (local variant of greploop for huge PRs; no separate upstream) |
-| `unslop` | this repo, vendored from [cursor/plugins (pstack)](https://github.com/cursor/plugins/tree/main/pstack/skills/unslop) with `disable-model-invocation` dropped so agents can apply it unprompted |
+| `unslop` | this repo, vendored from [cursor/plugins (pstack)](https://github.com/cursor/plugins/tree/main/pstack/skills/unslop); frontmatter edited so agents apply it unprompted (`disable-model-invocation` dropped, description scoped to text the agent writes or edits for people), body untouched |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,15 @@ Ship-beat notes:
 - The default upload host (0x0.st) is public — fine for ordinary UI shots;
   pass `--upload-url` for anything sensitive.
 
+## Writing for humans
+
+Run `/unslop` over anything a person will read, before you commit, post, or
+send it: commit messages, the PR title and body, README and doc edits, code
+comments, and the closing reply. It strips AI tells (em dashes, filler,
+hedging, chatbot phrases, puffery, bold-label lists) and replaces fancy
+words with plain ones and passive voice with active. Apply it to text you
+wrote or changed, not to prose you didn't touch.
+
 ## Multi-agent rules
 
 - Never commit directly to `main`.
@@ -63,7 +72,7 @@ Ship-beat notes:
    branch, `--force-with-lease`).
 6. Open the PR. The body must explain what changed, how it was tested (every
    claim backed by evidence), before/after proof, and any risks or follow-up
-   work.
+   work. Run the title and body through `/unslop` before posting.
 7. Run `/greploop` (or `/greploop-apps`) until **5/5 with zero unresolved
    comments**.
 8. End by presenting the PR URL.
@@ -86,3 +95,4 @@ infrastructure (stubs, fixtures), and anything that can't be tested locally.
 | `before-and-after` | this repo, vendored from [vercel-labs/before-and-after](https://github.com/vercel-labs/before-and-after) (or `npx skills add vercel-labs/before-and-after`) |
 | `greploop` | this repo, vendored from [greptileai/skills](https://github.com/greptileai/skills) |
 | `greploop-apps` | this repo (local variant of greploop for huge PRs; no separate upstream) |
+| `unslop` | this repo, vendored from [cursor/plugins (pstack)](https://github.com/cursor/plugins/tree/main/pstack/skills/unslop) with `disable-model-invocation` dropped so agents can apply it unprompted |

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 A collection of [agent skills](https://code.claude.com/docs/en/skills) for Claude Code. Each skill is a folder containing a `SKILL.md` with frontmatter (name, description) and instructions that Claude loads on demand when the task matches.
 
-## Available Skills
+## Available skills
 
 ### [before-and-after](before-and-after/SKILL.md)
 
-Captures before/after screenshots of web pages or elements and outputs a PR-ready markdown comparison table, driving the `@vercel/before-and-after` CLI.
+Captures before/after screenshots of web pages or elements and outputs a PR-ready markdown comparison table. It drives the `@vercel/before-and-after` CLI.
 
 Use it when:
 
@@ -14,7 +14,7 @@ Use it when:
 - You want a `| Before | After |` table generated and uploaded in one step
 - Comparing two URLs, two existing images, or a mix of both
 
-> Vendored from [vercel-labs/before-and-after](https://github.com/vercel-labs/before-and-after) (PolyForm Shield 1.0.0 — license included in the folder). Install the CLI with `npm i -g @vercel/before-and-after agent-browser`.
+> Vendored from [vercel-labs/before-and-after](https://github.com/vercel-labs/before-and-after) (PolyForm Shield 1.0.0, license included in the folder). Install the CLI with `npm i -g @vercel/before-and-after agent-browser`.
 
 ### [code-structure](code-structure/SKILL.md)
 
@@ -31,7 +31,7 @@ Includes a migration checklist for extracting shared logic safely and a table of
 
 ### [evidence-driven-testing](evidence-driven-testing/SKILL.md)
 
-Records visual proof while testing UI behavior — the agent drives the app live via computer use (or [cua-driver](https://github.com/trycua/cua) when the harness has no computer-use tools) while the bundled recorder captures the session — then posts the video and a results summary to the PR and tracker issue. The recorder (`scripts/evidence.py`, Python 3 + FFmpeg) runs on Linux, macOS, and Windows and has `doctor`, `start`, `annotate`, and `stop` commands: annotations are timestamped as the agent tests, burned into `evidence.mp4` on stop, and summarized in a generated `report.md` and `manifest.json`. Headless environments swap the recorder for scripted screenshots and Playwright captures; non-UI changes still get evidence (measured numbers, output pairs, transcript excerpts).
+Records visual proof while testing UI behavior. The agent drives the app live via computer use (or [cua-driver](https://github.com/trycua/cua) when the harness has no computer-use tools) while the bundled recorder captures the session, then posts the video and a results summary to the PR and tracker issue. The recorder (`scripts/evidence.py`, Python 3 + FFmpeg) runs on Linux, macOS, and Windows and has `doctor`, `start`, `annotate`, and `stop` commands. It timestamps each annotation as the agent tests, burns them into `evidence.mp4` on stop, and summarizes them in a generated `report.md` and `manifest.json`. Headless environments swap the recorder for scripted screenshots and Playwright captures; non-UI changes still get evidence (measured numbers, output pairs, transcript excerpts).
 
 Use it whenever a change needs verifiable evidence that it works, instead of prose claims.
 
@@ -41,21 +41,21 @@ Use it whenever a change needs verifiable evidence that it works, instead of pro
 
 Iteratively fixes a PR (GitHub), MR (GitLab), or shelved changelist (Perforce) until Greptile gives a perfect review: 5/5 confidence with zero unresolved comments. Triggers the review, fixes actionable comments, resolves threads, pushes, and repeats, up to `--max-iterations` cycles (default 10).
 
-Use it when a PR should be fully optimized against Greptile's code review standards before merge.
+Use it to get a PR to a clean Greptile review before merge.
 
-> Vendored from [greptileai/skills](https://github.com/greptileai/skills) (MIT — license included in the folder). Requires Greptile installed on the repo and an authenticated `gh`/`glab`/`p4` CLI.
+> Vendored from [greptileai/skills](https://github.com/greptileai/skills) (MIT, license included in the folder). Requires Greptile installed on the repo and an authenticated `gh`/`glab`/`p4` CLI.
 
 ### [greploop-apps](greploop-apps/SKILL.md)
 
-Identical loop to greploop, but triggers reviews by tagging `@greptile-apps`, which bypasses Greptile's file-count limit on huge PRs that the plain `@greptile` mention refuses to review — including a fallback that polls Greptile's edited summary comment when no check run appears.
+The same loop as greploop, but it triggers reviews by tagging `@greptile-apps`, which bypasses Greptile's file-count limit on huge PRs that the plain `@greptile` mention refuses to review. When no check run appears, it falls back to polling Greptile's edited summary comment.
 
 Use it when greploop's trigger gets "Too many files changed for review".
 
-> Local variant derived from greptileai's greploop (MIT — license included in the folder); no separate upstream.
+> Local variant derived from greptileai's greploop (MIT, license included in the folder); no separate upstream.
 
 ### [new-feature](new-feature/SKILL.md)
 
-Starts every new task in an isolated Git worktree branched from `origin/main` — unique task naming, a scope check against open PRs, fresh dependency installs, and cleanup after merge — so multiple agents can work on the same repo in parallel without conflicts.
+Starts every new task in an isolated Git worktree branched from `origin/main` so multiple agents can work on the same repo in parallel without conflicts. It covers unique task naming, a scope check against open PRs, fresh dependency installs, and cleanup after merge.
 
 Use it when:
 
@@ -74,11 +74,11 @@ Use it when:
 - Writing anything a person will read: commit messages, PR titles and bodies, docs, README edits, code comments, chat replies
 - Cleaning up existing text that reads machine-made
 
-> Vendored from [cursor/plugins (pstack)](https://github.com/cursor/plugins/tree/main/pstack/skills/unslop) (MIT, license included in the folder). Two frontmatter changes from upstream, both so agents apply the skill on their own instead of waiting for a typed `/unslop`: the `disable-model-invocation: true` line is dropped, and the description names the trigger (text you write or edit for a human reader) in place of upstream's "any writing. Must always apply.", so auto-invocation matches the scope `AGENTS.md` gives it. The body is untouched. Restore the flag if you want slash-command-only behavior.
+> Vendored from [cursor/plugins (pstack)](https://github.com/cursor/plugins/tree/main/pstack/skills/unslop) (MIT, license included in the folder). The body matches upstream; the frontmatter has two edits so agents apply the skill on their own instead of waiting for a typed `/unslop`. We dropped the `disable-model-invocation: true` line, and the description now names the trigger (text you write or edit for a human reader) in place of upstream's "any writing. Must always apply.", so auto-invocation matches the scope `AGENTS.md` gives it. Restore the flag if you want slash-command-only behavior.
 
 ## Workflow
 
-[`AGENTS.md`](AGENTS.md) ties the skills together into a four-beat workflow — isolate (`new-feature`) → build (`code-structure`) → prove (`evidence-driven-testing`) → ship (`before-and-after` + `greploop`), with `unslop` applied to everything written for humans along the way. Drop it into a repo alongside the skills and fill in the repo-specific callouts (checks, invariants, environment).
+[`AGENTS.md`](AGENTS.md) ties the skills together into a four-beat workflow: isolate (`new-feature`) → build (`code-structure`) → prove (`evidence-driven-testing`) → ship (`before-and-after` + `greploop`), with `unslop` applied to everything written for humans along the way. Drop it into a repo alongside the skills and fill in the repo-specific callouts (checks, invariants, environment).
 
 ## Installation
 
@@ -94,8 +94,8 @@ cp -r code-structure /path/to/project/.claude/skills/
 
 Claude Code picks up the skill automatically and invokes it when a task matches the skill's description. You can also invoke one explicitly with `/code-structure` or `/evidence-driven-testing`.
 
-## Adding a New Skill
+## Adding a new skill
 
 1. Create a folder named after the skill (kebab-case).
-2. Add a `SKILL.md` with `name` and `description` frontmatter — the description is what Claude uses to decide when the skill applies, so make it trigger-focused ("Use when...").
+2. Add a `SKILL.md` with `name` and `description` frontmatter. The description is what Claude uses to decide when the skill applies, so make it trigger-focused ("Use when...").
 3. Keep instructions concise and actionable; link out to reference files in the folder if they get long.

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Use it when:
 - Writing anything a person will read: commit messages, PR titles and bodies, docs, README edits, code comments, chat replies
 - Cleaning up existing text that reads machine-made
 
-> Vendored from [cursor/plugins (pstack)](https://github.com/cursor/plugins/tree/main/pstack/skills/unslop) (MIT, license included in the folder). One change from upstream: the `disable-model-invocation: true` frontmatter line is dropped so agents apply the skill on their own instead of waiting for a typed `/unslop`. Put it back if you want slash-command-only behavior.
+> Vendored from [cursor/plugins (pstack)](https://github.com/cursor/plugins/tree/main/pstack/skills/unslop) (MIT, license included in the folder). Two frontmatter changes from upstream, both so agents apply the skill on their own instead of waiting for a typed `/unslop`: the `disable-model-invocation: true` line is dropped, and the description names the trigger (text you write or edit for a human reader) in place of upstream's "any writing. Must always apply.", so auto-invocation matches the scope `AGENTS.md` gives it. The body is untouched. Restore the flag if you want slash-command-only behavior.
 
 ## Workflow
 

--- a/README.md
+++ b/README.md
@@ -65,9 +65,20 @@ Use it when:
 
 Includes harness deltas for Claude Code and Cursor, which manage worktrees themselves.
 
+### [unslop](unslop/SKILL.md)
+
+Edits prose to remove AI tells and put a human voice back in. It names 31 patterns to catch (puffery, filler, hedging, chatbot phrases, em dashes, colons as connectors, bold and emoji overuse, abstract metaphor nouns, passive voice) and a short checklist for adding opinion and rhythm, applied as a four-step loop: scan, rewrite, add soul, self-audit.
+
+Use it when:
+
+- Writing anything a person will read: commit messages, PR titles and bodies, docs, README edits, code comments, chat replies
+- Cleaning up existing text that reads machine-made
+
+> Vendored from [cursor/plugins (pstack)](https://github.com/cursor/plugins/tree/main/pstack/skills/unslop) (MIT, license included in the folder). One change from upstream: the `disable-model-invocation: true` frontmatter line is dropped so agents apply the skill on their own instead of waiting for a typed `/unslop`. Put it back if you want slash-command-only behavior.
+
 ## Workflow
 
-[`AGENTS.md`](AGENTS.md) ties the skills together into a four-beat workflow — isolate (`new-feature`) → build (`code-structure`) → prove (`evidence-driven-testing`) → ship (`before-and-after` + `greploop`). Drop it into a repo alongside the skills and fill in the repo-specific callouts (checks, invariants, environment).
+[`AGENTS.md`](AGENTS.md) ties the skills together into a four-beat workflow — isolate (`new-feature`) → build (`code-structure`) → prove (`evidence-driven-testing`) → ship (`before-and-after` + `greploop`), with `unslop` applied to everything written for humans along the way. Drop it into a repo alongside the skills and fill in the repo-specific callouts (checks, invariants, environment).
 
 ## Installation
 

--- a/unslop/LICENSE
+++ b/unslop/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Lauren Tan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/unslop/SKILL.md
+++ b/unslop/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: unslop
+description: Cut AI tells from any writing. Must always apply.
+---
+
+# Unslop
+
+Edit text to remove AI patterns and add human voice.
+
+## Process
+
+1. Scan for the patterns below.
+2. Rewrite. Preserve meaning, match intended tone.
+3. Add soul (see next section).
+4. Self-audit: "What makes this obviously AI generated?" Fix remaining tells.
+
+## Adding soul
+
+Removing patterns is half the job. Sterile, voiceless writing is just as obvious.
+
+- **Have opinions.** React to facts instead of neutrally listing pros and cons.
+- **Vary rhythm.** Short sentences. Then longer ones that take their time. Mix it up.
+- **Acknowledge complexity.** "Impressive but also kind of unsettling" beats "impressive."
+- **Use "I" when it fits.** First person isn't unprofessional.
+- **Let some mess in.** Perfect structure looks machine-made.
+- **Be specific.** Not "this is concerning" but "there's something unsettling about agents churning away at 3am."
+
+## Patterns to detect and fix
+
+### Content
+
+1. **Puffery.** "pivotal moment", "testament to", "evolving landscape", "setting the stage for", "indelible mark", "deeply rooted". Cut puffery, state what happened.
+2. **Name-dropping.** Listing media outlets without context. Pick one, say what was said.
+3. **Superficial -ing phrases.** "highlighting...", "ensuring...", "reflecting...", "showcasing...", "fostering...". Delete or expand with real sources.
+4. **Promotional language.** "nestled", "vibrant", "breathtaking", "groundbreaking", "renowned", "stunning", "must-visit". Use neutral descriptions.
+5. **Vague attributions.** "Experts believe", "Industry reports suggest", "Some critics argue". Name the source or delete.
+6. **Formulaic challenges.** "Despite challenges... continues to thrive." Replace with specific facts.
+
+### Language
+
+7. **AI vocabulary.** Additionally, crucial, delve, enduring, enhance, fostering, garner, interplay, intricate, landscape (abstract), pivotal, showcase, tapestry (abstract), testament, underscore, vibrant. Replace with plain words.
+8. **Fancy ways to say "is".** "serves as", "stands as", "boasts", "features". Just say "is" or "has".
+9. **"Not just X, but Y."** State the point directly instead.
+10. **Rule of three.** Forcing ideas into groups of three. Use the natural number.
+11. **Synonym cycling.** Protagonist, main character, central figure, hero all in one paragraph. Pick one, repeat it.
+12. **False ranges.** "from X to Y" where X and Y aren't on a meaningful scale. List topics directly.
+
+### Style
+
+13. **Em dash overuse.** Avoid em dashes entirely. Use periods or commas only (no parentheses, no en dashes, no hyphen-as-dash substitutes). Em dashes are an AI tell, and reaching for parentheses instead just trades one tell for another. If a thought needs separation, end the sentence or use a comma.
+14. **Colon overuse.** Colons are fine before a list or example. Not as mid-sentence connectors. "If you're coming from traditional automation: instead of registering event handlers, you describe conditions" adds nothing with the colon. Rewrite to let the point stand on its own without comparison framing. "Describing when the scheduler should fire works best as plain English." Same meaning, no crutch punctuation.
+15. **Boldface overuse.** Don't bold every proper noun or acronym.
+16. **Inline-header lists.** The tell is a bold label and colon that restates the line: "**Performance:** Performance improved...". Convert those to prose. A bold lead-in that ends in a period, names the item, and is followed by genuinely new detail ("**Schema in TypeScript.** Tables live in one file.") is fine, not a tell.
+17. **Title case headings.** Use sentence case.
+18. **Decorative emojis.** Remove from headings and bullets.
+19. **Curly quotes.** Replace with straight quotes.
+
+### Communication artifacts
+
+20. **Chatbot phrases.** "I hope this helps!", "Let me know if...", "Of course!", "Certainly!", "Found the smoking gun!" Remove.
+21. **Cutoff disclaimers.** "While specific details are limited..." Find sources or remove.
+22. **Sycophantic tone.** "Great question! You're absolutely right!" Respond directly.
+
+### Filler
+
+23. **Filler phrases.** "In order to" becomes "To". "Due to the fact that" becomes "Because". "It is important to note that" gets deleted.
+24. **Excessive hedging.** "could potentially possibly be argued that it might" becomes "may".
+25. **Generic conclusions.** "The future looks bright." State specific plans or facts.
+
+### Jargon
+
+26. **Abstract metaphor nouns.** Substrate, wedge, vector, locus, vantage, nexus, primitive (as noun), harness (as metaphor), surface (as in "API surface"), bedrock, scaffolding (as metaphor), modality, paradigm, gold-plating, ratchet (as metaphor), evacuate (for moving code), endgame, north star, flywheel. These read as technical but usually have a plainer concrete word. "Substrate" becomes "base". "Wedge in" becomes "add". "Vector" becomes "way" or "method". "Gold-plating" becomes "more than the job needs". "Ratchet" becomes the mechanism's real name or "a limit that only tightens". "Evacuate" becomes "move out". "Endgame" becomes "the last phase". Pick the concrete word.
+
+### Plain speech
+
+27. **Say what it does, not how it feels.** "the database stays close at hand", "SQL you can read", "types that follow your schema" name a feeling. The fix names the mechanism or a number: "`.toSQL()` returns the exact string sent to the database", "a column rename fails the build". Ask what the sentence tells the reader to do or know, then write that. If you can't restate it as a concrete instruction, fact, or number, cut it. One more check: if the sentence could appear unchanged in another project's docs, it says nothing about this one. Cut it.
+28. **Shorten or split dense sentences.** If the reader has to backtrack to parse a sentence, break it in two or drop clauses. One idea per sentence.
+29. **Active voice.** Prefer it. Catch "is/are/was/were + past participle" and name the actor: "queries are validated" becomes "the compiler validates queries", "the file is parsed by the loader" becomes "the loader parses the file". Passive is fine only when the actor is unknown or genuinely doesn't matter.
+30. **Cut adverbs, or use a stronger verb.** "runs quickly" becomes "is fast" or the number. "significantly improves" becomes the measured delta. An adverb propping up a weak verb means the verb is wrong.
+31. **Prefer the plain word.** "utilize" becomes "use", "leverage" becomes "use", "facilitate" becomes "help", "numerous" becomes "many", "in the event that" becomes "if". The fancier synonym is rarely clearer.

--- a/unslop/SKILL.md
+++ b/unslop/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: unslop
-description: Cut AI tells from any writing. Must always apply.
+description: Cut AI tells from text you write or edit for a human reader (commit messages, PR titles and bodies, docs, code comments, replies). Apply before committing, posting, or sending; leave prose you didn't touch alone.
 ---
 
 # Unslop


### PR DESCRIPTION
## What changed

- `unslop/SKILL.md`: the pstack `unslop` skill from [cursor/plugins](https://github.com/cursor/plugins/tree/main/pstack/skills/unslop), pinned to upstream `73f8be4` (2026-09-01). The download's git blob hash matched upstream's `ccb0c55` byte for byte before the one edit below.
- `unslop/LICENSE`: pstack's MIT license, verbatim, following how `greploop` and `before-and-after` are vendored here.
- Two deliberate frontmatter changes to the skill; the body is byte-identical to upstream.
  - The `disable-model-invocation: true` line is dropped. Upstream added it two days ago in [cursor/plugins#300](https://github.com/cursor/plugins/pull/300). In Cursor that flag makes a skill slash-command only, so agents would never apply it unless a human typed `/unslop`, which defeats wiring it into AGENTS.md. The README entry says how to put it back.
  - The description is rescoped from "any writing. Must always apply." to text the agent writes or edits for a human reader, with the trigger spelled out (before committing, posting, or sending). With the flag gone the description is what drives auto-invocation, so it has to match the boundary AGENTS.md sets. This came out of Greptile's first review.
- `AGENTS.md`: a "Writing for humans" section that scopes `/unslop` to text the agent wrote (commit messages, PR title and body, doc edits, code comments, the closing reply), a reminder at the open-the-PR step, and a row in the skill sources table.
- `README.md`: an entry for the skill and a clause in the workflow paragraph. A second commit (`957cf10`) then runs unslop over the rest of the README: sentence splits in place of em dashes, sentence-case headings, active voice in the evidence-driven-testing entry. Facts and links are unchanged.

## How it was tested

A repo-level check (kept outside the repo) lists skill folders, validates every `SKILL.md` frontmatter (`name` matches the folder, `description` present), resolves every relative link in `AGENTS.md` and `README.md`, and diffs `unslop/SKILL.md` against the pinned upstream file. It fails unless the frontmatter diff is exactly the two documented changes, the body after the frontmatter is byte-identical to upstream, and the LICENSE is present.

- Check: `RESULT: FAIL` before, `RESULT: PASS` after (output below).
- Repo tests: `python3 -m pytest tests/ -q` gives `23 passed` before and after.
- `git diff --cached --check`: clean.
- README pass: a counter for the tells unslop names that are countable (em dashes, en dashes as dashes, curly quotes, "not just X but Y", AI vocabulary, filler phrases, title-case headings, `is/are + -ed` passives, sentences over 45 words) reads 17 before and 0 after, with all 8 relative links still resolving. Numbers below.

## Before / after

Before, at `dfe71d0` (`origin/main`):

```
== skill folders (6): before-and-after, code-structure, evidence-driven-testing, greploop, greploop-apps, new-feature
== AGENTS.md: 0 mention(s) of 'unslop'; 0 relative link(s), 0 broken
== README.md: 0 mention(s) of 'unslop'; 7 relative link(s), 0 broken
== unslop/SKILL.md vs upstream cursor/plugins@73f8be4
  unslop/SKILL.md: MISSING
  unslop/LICENSE: MISSING

RESULT: FAIL
```

After, at `a007fcd`:

```
== skill folders (7): before-and-after, code-structure, evidence-driven-testing, greploop, greploop-apps, new-feature, unslop
  unslop: name=unslop                   description=yes disable-model-invocation=unset -> ok
== AGENTS.md: 4 mention(s) of 'unslop'; 0 relative link(s), 0 broken
== README.md: 5 mention(s) of 'unslop'; 8 relative link(s), 0 broken
== unslop/SKILL.md vs upstream cursor/plugins@73f8be4
  3 changed line(s) out of 81
  @@ -3,2 +3 @@
  -description: Cut AI tells from any writing. Must always apply.
  -disable-model-invocation: true
  +description: Cut AI tells from text you write or edit for a human reader (commit messages, PR titles and bodies, docs, code comments, replies). Apply before committing, posting, or sending; leave prose you didn't touch alone.
  frontmatter: only the two documented changes
  body after frontmatter: byte-identical to upstream
  unslop/LICENSE: present (MIT License; Copyright (c) 2026 Lauren Tan)

RESULT: PASS
```

README tells, before (`a007fcd`) and after (`957cf10`):

| Tell | Before | After |
|---|---:|---:|
| em dashes | 10 | 0 |
| title-case headings | 2 | 0 |
| passive `is/are + -ed` | 3 | 0 |
| sentences over 45 words | 2 | 0 |
| en dashes, curly quotes, "not just X but Y", AI vocabulary, filler | 0 | 0 |
| **total** | **17** | **0** |

## Risks and follow-ups

- With the flag dropped, agents will load this 6.6 KB skill whenever they are about to commit, post, or reply, which is most tasks. That matches how the skill has run from `~/.cursor/skills` since August, before upstream added the flag. Restore the line for slash-only behavior.
- The description now differs from upstream, so future re-vendoring needs to carry the two frontmatter edits forward. The README note lists them.
- AGENTS.md still uses em dashes in prose this PR didn't write, which the skill flags. Left alone here; the new section tells agents to apply unslop to text they wrote, not to prose they didn't touch. The README got the pass because the request asked for it.
