### PR TITLE
feat: add fix-video-evidence skill (Playwright-only before/after fix recorder)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,20 @@ Use it whenever a change needs verifiable evidence that it works, instead of pro
 
 > The recorder needs `ffmpeg`/`ffprobe` built with `libx264` and the `ass` filter, plus a screen-capture source: X11 (`DISPLAY`) or wlroots Wayland (`wf-recorder`; GNOME/KDE are not supported) on Linux, Screen Recording permission on macOS, any standard ffmpeg on Windows. `python3 scripts/evidence.py doctor` reports both. The raw capture is MPEG-TS, so a crashed or hard-killed recorder still yields usable evidence. The headless path needs only a running app and a scriptable browser (Playwright via npx). Posting evidence requires the `gh` CLI (or equivalent). `tests/test_evidence.py` smoke-tests the recorder end to end with a synthetic video source (`python3 -m pytest tests/ -q`).
 
+### [fix-video-evidence](fix-video-evidence/SKILL.md)
+
+Records the before/after of a bug-fix cycle as two short `.webm` videos using Playwright's built-in `recordVideo`, then attaches them to the PR. One reproduction script, two runs - `PHASE=before` on the pre-fix commit, `PHASE=after` on the post-fix commit - with the flow identical between phases so only the assertion flips.
+
+Use it when:
+
+- A bug is temporal or interactive and a still screenshot misses it (jank, focus jump, loading state that never resolves, off-screen redirect)
+- You want video evidence of a fix without the full computer-use + Python + FFmpeg stack `evidence-driven-testing` requires
+- You already have Playwright in the target repo (or can add it)
+
+Portable mode is the default: the helper prints a copy-paste markdown block and a 5-second drag-drop recipe (GitHub inlines the `.webm` in the comment). R2 auto-upload is opt-in via env vars, with a `setup-r2.sh` wizard that walks you through Cloudflare's free tier in ~5 minutes and tests the actual upload before declaring success.
+
+> Complementary to `evidence-driven-testing`: use that skill for full computer-use-driven UI testing with annotated MP4 output; use this one for the narrower "record the before/after of one fix" workflow when Playwright is enough.
+
 ### [greploop](greploop/SKILL.md)
 
 Iteratively fixes a PR (GitHub), MR (GitLab), or shelved changelist (Perforce) until Greptile gives a perfect review: 5/5 confidence with zero unresolved comments. Triggers the review, fixes actionable comments, resolves threads, pushes, and repeats, up to `--max-iterations` cycles (default 10).

--- a/fix-video-evidence/SKILL.md
+++ b/fix-video-evidence/SKILL.md
@@ -1,0 +1,194 @@
+---
+name: fix-video-evidence
+description: Use to record two short videos of a bug-fix cycle (broken state on the pre-fix commit, working state on the post-fix commit) and attach them to the PR. Trigger on "record fix video", "video proof of fix", "before/after video", "attach video to PR", "PR video evidence", "reproduce and record the bug", or any request to hand a reviewer a moving-picture demo instead of just screenshots. Uses Playwright's built-in recordVideo — no paid API, no extra service. Portable-mode (drag-and-drop the .webm into the PR comment box) is default; auto-upload to R2 is opt-in via env vars.
+---
+
+# Fix Video Evidence
+
+## Overview
+
+The Claude Code equivalent of Cursor Cloud's "record a video of the fix" pattern. On the pre-fix commit you record the bug reproducing; on the post-fix commit you re-run the same script and record it working. Two `.webm` files, both attached to the PR. Static screenshots answer "did the pixels change?"; video answers "did the flow actually work?" — much stronger craft signal for a reviewer.
+
+This skill wraps the record + attach cycle. **The fix itself is out of scope** — you (or another skill / agent) apply the code fix between the two recordings.
+
+> **Project rule precedence:** if the repo's `CLAUDE.md` / `AGENTS.md` sets a stricter QA gate (e.g. a mandated machine-human browser QA checklist), honor it. This skill produces evidence for that gate, it doesn't replace it.
+
+## When to Use
+
+- Any bug-fix PR the reviewer will want to *see*: interactive UI, a broken flow, a regression, a visual bug that a still screenshot misses.
+- Portfolio-facing repos where every PR should carry proof-of-craft.
+- Anywhere `before-and-after` (still screenshots) is not enough because the bug is temporal (loading state that never resolves, jank, wrong sequence, off-screen redirect, focus jump).
+
+**Don't** use for pure-backend PRs with no rendered surface, docs-only PRs, or refactors with no behavior change — a video of nothing changing is noise.
+
+## Prerequisites (fail-loud, install nothing globally)
+
+Check, don't install:
+
+```bash
+# In the target repo:
+test -f package.json || { echo "No package.json — install Playwright in the repo first"; exit 1; }
+npx --no-install playwright --version 2>/dev/null || {
+  echo "Playwright not installed. In the target repo, run:"
+  echo "  npm i -D @playwright/test"
+  echo "  npx playwright install chromium"
+  exit 1
+}
+gh auth status 2>&1 | grep -q "Logged in" || { echo "gh not authenticated. Run: gh auth login"; exit 1; }
+```
+
+If any of the three fails, **stop and print the fix**. Do not npm-install into the user's project without permission. Do not proceed silently.
+
+## Step 1 — Locate the PR + set naming
+
+```bash
+REPO_NAME=$(basename "$(git rev-parse --show-toplevel)")
+PR_NUM=$(gh pr view --json number -q .number 2>/dev/null) || {
+  echo "No PR for the current branch. Push the branch and open a PR first (gh pr create)."
+  exit 1
+}
+mkdir -p .videos
+grep -qxF ".videos/" .gitignore 2>/dev/null || echo ".videos/" >> .gitignore
+```
+
+Filenames are `<repo>-<pr>-before.webm` and `<repo>-<pr>-after.webm`. That is the naming convention — do not vary it, `attach-to-pr.sh` grep's for it.
+
+## Step 2 — Write the reproduction script
+
+Copy the template into the repo (not tracked — the .videos/ location is fine, or a scratch dir):
+
+```bash
+cp ~/.claude/skills/fix-video-evidence/reference/playwright-template.mjs .videos/repro.mjs
+```
+
+Then edit `.videos/repro.mjs` for the specific bug:
+- Set `TARGET_URL` (the deployed preview, staging, or `http://localhost:<port>`).
+- Fill in the reproduction steps (`click`, `fill`, `waitFor`).
+- Leave BOTH the "before" and "after" assertion blocks in place — a `PHASE=before|after` env var flips which one runs. Keep the flow above them identical between phases; that is the whole point.
+
+**One script, two runs.** Never write two scripts — divergence between them is exactly the failure mode this skill exists to catch.
+
+## Step 3 — Record the BEFORE (bug reproduces)
+
+On the pre-fix commit (or `git stash` your fix if it's already in your working tree):
+
+```bash
+git stash push -u -m "fix-video-evidence: temporarily park fix" || true
+PHASE=before PR_NUM=$PR_NUM REPO_NAME=$REPO_NAME \
+  npx playwright test .videos/repro.mjs --reporter=line
+```
+
+The context is created with `recordVideo: { dir: '.videos/', size: { width: 1280, height: 720 } }`, and the template renames the raw output to `<repo>-<pr>-before.webm` on teardown.
+
+Check it played the bug back:
+```bash
+ls -lh .videos/*-before.webm
+# On macOS: open .videos/*-before.webm     (QuickTime plays .webm via extensions; else use VLC / a browser: file://…)
+```
+
+If the assertion in the "before" phase FAILED (the bug didn't reproduce), the script is wrong — fix the reproduction, not the fix. A "before" video without the visible bug is worthless.
+
+## Step 4 — Apply the fix, then record the AFTER
+
+Pop the fix back (or apply it now if you hadn't yet):
+
+```bash
+git stash pop || true
+# ... apply the code fix, commit it ...
+PHASE=after PR_NUM=$PR_NUM REPO_NAME=$REPO_NAME \
+  npx playwright test .videos/repro.mjs --reporter=line
+ls -lh .videos/*-after.webm
+```
+
+The "after" phase asserts the fix (the flow completes, the error is gone, the correct state renders). If that assertion fails, the fix isn't done — do not attach a passing-looking video.
+
+## Step 5 — Size-check before attaching (GitHub's 10MB cap)
+
+GitHub's comment-box video upload caps at ~10MB per file. Check both:
+
+```bash
+find .videos -name "*-${PR_NUM}-*.webm" -exec ls -lh {} \; \
+  -exec sh -c 'test $(stat -f%z "$1" 2>/dev/null || stat -c%s "$1") -gt 10485760 \
+    && echo "WARN: $1 exceeds 10MB — trim the reproduction, drop the viewport, or use PR_VIDEO_UPLOAD=r2"' _ {} \;
+```
+
+If either is over 10MB: shorten the reproduction (fewer `waitForTimeout` calls, tighter viewport, headless-first), or switch to auto-upload mode (Step 6b).
+
+## Step 6a — Portable mode (default): drag-and-drop into the PR
+
+> **When to prefer this**: one-off PRs, or your first time using the skill. 5 seconds of drag-drop per PR, works on any machine with no cloud config. If you'll run this on many PRs, R2 auto-upload (Step 6b) is faster in aggregate - 5-minute one-time setup via the wizard, then zero-touch forever.
+
+```bash
+bash ~/.claude/skills/fix-video-evidence/reference/attach-to-pr.sh $PR_NUM
+```
+
+That prints a ready-to-paste markdown block like:
+
+```md
+### Fix evidence
+
+| Before (bug) | After (fix) |
+|---|---|
+| _drag `.videos/<repo>-<pr>-before.webm` here_ | _drag `.videos/<repo>-<pr>-after.webm` here_ |
+```
+
+Open the PR in a browser, paste the markdown into a comment, then drag each `.webm` from Finder onto its cell. GitHub uploads them and rewrites the placeholder to a `<video>` embed. This works from any machine, no cloud config needed.
+
+## Step 6b — Auto-upload mode (opt-in): R2 → CDN URL → `gh pr edit`
+
+**First-time R2 setup**: run the guided wizard once and never think about it again.
+
+```bash
+bash ~/.claude/skills/fix-video-evidence/reference/setup-r2.sh
+```
+
+It opens the Cloudflare dashboard, walks you through bucket + API token creation, tests an actual upload, and prints the four `R2_*` `export` lines to paste into your shell profile. Cloudflare's R2 free tier (10GB storage + 1M ops/month) covers a lot of PR videos - no card required for sign-up.
+
+Or, if you prefer manual setup, set the four R2 env vars yourself (any S3-compatible R2 bucket the user already owns):
+
+```bash
+export PR_VIDEO_UPLOAD=r2
+export R2_BUCKET=<bucket>
+export R2_ACCOUNT_ID=<id>
+export R2_ACCESS_KEY_ID=<key>
+export R2_SECRET_ACCESS_KEY=<secret>
+# Optional: R2_PUBLIC_BASE=https://cdn.example.com   (else uses the r2.dev URL from `wrangler r2` or the default account subdomain)
+```
+
+Then:
+
+```bash
+bash ~/.claude/skills/fix-video-evidence/reference/attach-to-pr.sh $PR_NUM
+```
+
+The helper detects `PR_VIDEO_UPLOAD=r2`, uploads both files via `reference/upload-r2.sh` (uses `aws s3 cp` against the R2 S3 endpoint), and appends the CDN-linked markdown to the PR body via `gh pr edit --body-file`. No hardcoded bucket name — everything reads from env.
+
+If the R2 env vars are missing but `PR_VIDEO_UPLOAD=r2` is set, the helper falls back to portable-mode output with a warning. Never silently drops the evidence.
+
+## Gotchas
+
+1. **`.webm` on GitHub** — GitHub renders `.webm` inline in comments and PR bodies. Do NOT convert to `.mp4` "to be safe" — that adds ffmpeg dependency for no benefit.
+2. **Playwright's chromium is not on PATH after a fresh install** — always invoke via `npx playwright test`, never a bare `chromium` binary. `npx playwright install chromium` is a one-time-per-machine step; the skill's prereq check catches it.
+3. **The recorded video is finalized on context close.** Do not `process.exit()` mid-test — the template uses `test.afterAll` + `context.close()` so the `.webm` header is written correctly. A killed process leaves a zero-byte file.
+4. **Rename happens after close, not during.** Playwright names videos by the internal test id; the template's `afterAll` hook moves `.videos/*.webm` to `<repo>-<pr>-<phase>.webm`. If you see raw hex-named files, teardown didn't run.
+5. **Viewport bigger than 1280×720 balloons the file size fast.** Stick to 720p unless a bug is genuinely only visible at 1440p+.
+6. **Never record credential entry.** If the flow needs auth, log in headlessly BEFORE the `recordVideo` context opens (`storageState`), or blank the password field on-screen. A `.webm` in a public PR is public.
+7. **Claude Code's Bash tool resets cwd between calls** — always use absolute paths or re-`cd` in the same compound command. This skill's helpers assume they're invoked from the target repo root.
+8. **Do not commit `.videos/`.** The skill appends it to `.gitignore` on first run. If a `.webm` is somehow staged, unstage it — the PR embeds carry the file, the repo shouldn't.
+9. **Cursor's cloud videos vs this** — Cursor auto-records for cloud runs only. Locally-run Claude Code needs this skill; there is no equivalent native harness feature. Do not tell the user to "use the built-in" — there isn't one.
+
+## Follow-ups this skill deliberately does not do
+
+- No auto-caption / transcript. (Reviewer accessibility gap.)
+- No side-by-side single-video composite (would need ffmpeg).
+- No hosted-service fallback for users without R2 (portable mode is that fallback today).
+
+## Verification Checklist
+
+- [ ] Prereqs verified (Playwright installed in repo, `gh` authed, chromium browser installed).
+- [ ] ONE `repro.mjs` script; `PHASE=before` and `PHASE=after` flip only the assertion, not the flow.
+- [ ] Before video actually shows the bug (assertion `PHASE=before` passed).
+- [ ] After video actually shows the fix (assertion `PHASE=after` passed on the post-fix commit).
+- [ ] Both files ≤10MB OR auto-upload mode active.
+- [ ] Markdown attached to the PR (comment for portable, body for auto-upload).
+- [ ] `.videos/` in `.gitignore`; no `.webm` staged for commit.

--- a/fix-video-evidence/reference/attach-to-pr.sh
+++ b/fix-video-evidence/reference/attach-to-pr.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# fix-video-evidence — attach the two .webm files to the PR.
+#
+# Two modes:
+#   PORTABLE (default)         — prints a markdown block for the user to paste
+#                                into a PR comment and drag-and-drop the .webm on to.
+#   AUTO-UPLOAD (PR_VIDEO_UPLOAD=r2)
+#                              — uploads via reference/upload-r2.sh, then appends
+#                                CDN-linked markdown to the PR body via `gh pr edit`.
+#
+# If PR_VIDEO_UPLOAD=r2 but R2_* env vars are missing, falls back to portable
+# with a warning — never silently drops the evidence.
+#
+# Usage:  attach-to-pr.sh <pr-number>
+#
+# Expects filenames `<repo>-<pr>-before.webm` and `<repo>-<pr>-after.webm`
+# in .videos/ (produced by the Playwright template's afterAll hook).
+
+set -euo pipefail
+
+pr="${1:?usage: attach-to-pr.sh <pr-number>}"
+repo="$(basename "$(git rev-parse --show-toplevel)")"
+here="$(cd "$(dirname "$0")" && pwd)"
+
+before=".videos/${repo}-${pr}-before.webm"
+after=".videos/${repo}-${pr}-after.webm"
+
+for f in "$before" "$after"; do
+  if [ ! -f "$f" ]; then
+    echo "attach-to-pr.sh: missing $f — run the Playwright script for both PHASE=before and PHASE=after first" >&2
+    exit 1
+  fi
+done
+
+size_ok () {   # $1=file — echo "OK" or a warning
+  local bytes
+  bytes=$(stat -f%z "$1" 2>/dev/null || stat -c%s "$1")
+  if [ "$bytes" -gt 10485760 ]; then
+    echo "WARN: $1 is $(( bytes / 1024 / 1024 ))MB — GitHub's comment-upload cap is ~10MB. Trim the reproduction or use PR_VIDEO_UPLOAD=r2." >&2
+  fi
+}
+size_ok "$before"
+size_ok "$after"
+
+mode="portable"
+if [ "${PR_VIDEO_UPLOAD:-}" = "r2" ]; then
+  if [ -z "${R2_BUCKET:-}" ] || [ -z "${R2_ACCOUNT_ID:-}" ] \
+     || [ -z "${R2_ACCESS_KEY_ID:-}" ] || [ -z "${R2_SECRET_ACCESS_KEY:-}" ]; then
+    echo "attach-to-pr.sh: PR_VIDEO_UPLOAD=r2 set but R2_* env vars missing — falling back to portable mode." >&2
+  else
+    mode="r2"
+  fi
+fi
+
+if [ "$mode" = "r2" ]; then
+  before_url=$(bash "$here/upload-r2.sh" "$before" "pr-evidence/${repo}-${pr}-before.webm")
+  after_url=$(bash  "$here/upload-r2.sh" "$after"  "pr-evidence/${repo}-${pr}-after.webm")
+
+  block=$(cat <<EOF
+
+### Fix evidence
+
+| Before (bug) | After (fix) |
+|---|---|
+| <video src="${before_url}" controls width="480"></video> | <video src="${after_url}" controls width="480"></video> |
+
+<sub>Recorded with Playwright \`recordVideo\` via the \`fix-video-evidence\` skill.</sub>
+EOF
+)
+
+  if command -v gh >/dev/null 2>&1; then
+    tmp=$(mktemp)
+    gh pr view "$pr" --json body -q .body > "$tmp"
+    printf '%s' "$block" >> "$tmp"
+    gh pr edit "$pr" --body-file "$tmp"
+    rm -f "$tmp"
+    echo "attach-to-pr.sh: appended CDN-linked evidence to PR #${pr} body."
+  else
+    echo "gh not found — paste this into the PR body yourself:"
+    echo "$block"
+  fi
+  exit 0
+fi
+
+# Portable mode.
+pr_url=$(gh pr view "$pr" --json url -q .url 2>/dev/null || echo "https://github.com/<owner>/<repo>/pull/${pr}")
+
+human_size () {
+  local bytes
+  bytes=$(stat -f%z "$1" 2>/dev/null || stat -c%s "$1")
+  if [ "$bytes" -ge 1048576 ]; then
+    awk -v b="$bytes" 'BEGIN { printf "%.1fMB", b/1048576 }'
+  else
+    awk -v b="$bytes" 'BEGIN { printf "%dKB", b/1024 }'
+  fi
+}
+before_size=$(human_size "$before")
+after_size=$(human_size "$after")
+
+cat <<EOF
+
+### Fix evidence
+
+| Before (bug) | After (fix) |
+|---|---|
+| _drag \`${before}\` here_ | _drag \`${after}\` here_ |
+
+<sub>Recorded with Playwright \`recordVideo\` via the \`fix-video-evidence\` skill.</sub>
+
+──────────────────────────────────────────────────────
+📎  5 seconds of drag-drop:
+
+  1. Open the PR:  ${pr_url}
+  2. Click Comment (bottom of the thread).
+  3. Paste the markdown table above.
+  4. Drag from Finder onto each placeholder:
+       • ${before}  (${before_size})
+       • ${after}   (${after_size})
+  5. Submit. GitHub inlines the .webm - reviewer plays it in-thread.
+
+💡  Doing this on more than a few PRs?  One-time 5-min setup makes it
+    zero-touch:
+
+       bash ${here}/setup-r2.sh
+──────────────────────────────────────────────────────
+EOF

--- a/fix-video-evidence/reference/playwright-template.mjs
+++ b/fix-video-evidence/reference/playwright-template.mjs
@@ -1,0 +1,100 @@
+// fix-video-evidence — Playwright reproduction template.
+//
+// ONE script, TWO runs. The `PHASE` env var flips which final assertion runs;
+// everything above the assertion block MUST stay identical between phases —
+// same navigation, same clicks, same waits. Divergence is the failure mode
+// this whole skill exists to catch.
+//
+// Usage from the target repo (invoked by the SKILL.md steps):
+//   PHASE=before PR_NUM=<n> REPO_NAME=<repo> npx playwright test .videos/repro.mjs --reporter=line
+//   PHASE=after  PR_NUM=<n> REPO_NAME=<repo> npx playwright test .videos/repro.mjs --reporter=line
+//
+// Output: .videos/<repo>-<pr>-<phase>.webm (renamed in afterAll).
+
+import { test, expect, chromium } from '@playwright/test';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+const PHASE      = process.env.PHASE      || 'before';   // 'before' | 'after'
+const PR_NUM     = process.env.PR_NUM     || 'local';
+const REPO_NAME  = process.env.REPO_NAME  || 'repo';
+const TARGET_URL = process.env.TARGET_URL || 'http://localhost:3000';   // <— set this per bug
+const VIDEO_DIR  = '.videos';
+
+let browser;
+let context;
+let page;
+
+test.beforeAll(async () => {
+  browser = await chromium.launch({ headless: true });
+  context = await browser.newContext({
+    viewport: { width: 1280, height: 720 },
+    recordVideo: { dir: VIDEO_DIR, size: { width: 1280, height: 720 } },
+    // If the app needs auth, add `storageState: '.videos/auth.json'` (a pre-baked
+    // logged-in state). NEVER type real credentials on-camera.
+  });
+  page = await context.newPage();
+});
+
+test.afterAll(async () => {
+  // Close the context FIRST so Playwright finalizes the .webm header.
+  // A killed process leaves a zero-byte file — this hook is why teardown matters.
+  await context?.close();
+  await browser?.close();
+
+  // Rename the auto-named .webm to the convention the attach helper greps for.
+  const target = path.join(VIDEO_DIR, `${REPO_NAME}-${PR_NUM}-${PHASE}.webm`);
+  const files  = (await fs.readdir(VIDEO_DIR)).filter(f => f.endsWith('.webm') && !f.includes(`${PR_NUM}-`));
+  // Take the freshest untagged .webm and rename it.
+  if (files.length) {
+    const withStats = await Promise.all(files.map(async f => {
+      const s = await fs.stat(path.join(VIDEO_DIR, f));
+      return { f, mtime: s.mtimeMs };
+    }));
+    withStats.sort((a, b) => b.mtime - a.mtime);
+    const freshest = path.join(VIDEO_DIR, withStats[0].f);
+    await fs.rm(target, { force: true });
+    await fs.rename(freshest, target);
+    console.log(`fix-video-evidence: wrote ${target}`);
+  } else {
+    console.error(`fix-video-evidence: no .webm found in ${VIDEO_DIR} — did teardown run?`);
+  }
+});
+
+test(`reproduce bug — phase=${PHASE}`, async () => {
+  // ────────────────────────────────────────────────────────────────
+  // SECTION A — reproduction flow (IDENTICAL across before/after)
+  // ────────────────────────────────────────────────────────────────
+  await page.goto(TARGET_URL, { waitUntil: 'networkidle' });
+
+  // EXAMPLE steps — replace with the actual bug's flow.
+  // await page.getByRole('button', { name: 'Sign in' }).click();
+  // await page.getByLabel('Email').fill('demo@example.com');
+  // await page.getByRole('button', { name: 'Continue' }).click();
+  // await page.getByRole('link', { name: 'New shift' }).click();
+
+  // Give the UI a beat to settle so the recording captures the state.
+  await page.waitForTimeout(500);
+
+  // ────────────────────────────────────────────────────────────────
+  // SECTION B — phase-specific assertion (this is the only branch)
+  // ────────────────────────────────────────────────────────────────
+  if (PHASE === 'before') {
+    // Assert the BUG is visible. If this fails, the reproduction is wrong —
+    // fix the reproduction, not the code. A "before" video without the bug is worthless.
+    // EXAMPLE:
+    // await expect(page.getByText(/failed to load/i)).toBeVisible();
+    // await expect(page.getByRole('button', { name: 'Save' })).toBeDisabled();
+    await expect(page.locator('body')).toBeVisible();   // placeholder — replace
+  } else {
+    // Assert the FIX works. If this fails on the post-fix commit, the fix isn't done —
+    // do NOT attach a passing-looking video.
+    // EXAMPLE:
+    // await expect(page.getByText(/saved/i)).toBeVisible();
+    // await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
+    await expect(page.locator('body')).toBeVisible();   // placeholder — replace
+  }
+
+  // Small tail so the video ends on the asserted state, not mid-transition.
+  await page.waitForTimeout(500);
+});

--- a/fix-video-evidence/reference/setup-r2.sh
+++ b/fix-video-evidence/reference/setup-r2.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# fix-video-evidence - one-time Cloudflare R2 setup wizard.
+#
+# Walks you through creating a Cloudflare R2 bucket + API token, tests
+# an actual upload, and prints the four R2_* env-var exports for your
+# shell profile. After running this once, PR_VIDEO_UPLOAD=r2 in your
+# environment makes attach-to-pr.sh auto-upload every future PR video.
+#
+# Cost: Cloudflare R2 free tier is 10GB storage + 1M Class A ops/month.
+# No card required for sign-up. Videos this skill uploads are ~1-5MB each,
+# so the free tier realistically covers thousands of PRs before you hit it.
+
+set -euo pipefail
+
+blue () { printf "\033[1;34m%s\033[0m\n" "$*"; }
+green () { printf "\033[1;32m%s\033[0m\n" "$*"; }
+red () { printf "\033[1;31m%s\033[0m\n" "$*"; }
+gray () { printf "\033[0;37m%s\033[0m\n" "$*"; }
+
+blue "fix-video-evidence - Cloudflare R2 setup wizard"
+gray "One-time setup that lets attach-to-pr.sh auto-upload .webm files instead of asking you to drag them into the PR by hand."
+echo ""
+
+here="$(cd "$(dirname "$0")" && pwd)"
+
+# Step 0: check if all four env vars are already set - if so, just test upload
+already_set=1
+for var in R2_BUCKET R2_ACCOUNT_ID R2_ACCESS_KEY_ID R2_SECRET_ACCESS_KEY; do
+  if [ -z "${!var:-}" ]; then already_set=0; break; fi
+done
+
+if [ "$already_set" = "1" ]; then
+  green "All four R2_* env vars are already set in this shell. Skipping wizard, testing the upload path directly..."
+else
+  gray "One or more R2_* env vars are missing. Starting the guided setup."
+  echo ""
+
+  blue "Step 1/5: Cloudflare account + R2 enabled"
+  echo "  You need a Cloudflare account with R2 enabled. Free tier (10GB + 1M ops/mo) is more than enough."
+  echo "    - Sign up:    https://dash.cloudflare.com/sign-up"
+  echo "    - Enable R2:  https://dash.cloudflare.com/?to=/:account/r2 (click 'Enable R2'; no card required for free tier)"
+  read -p "  Ready? Press Enter when you have a Cloudflare account and R2 is enabled. "
+  echo ""
+
+  blue "Step 2/5: Create the bucket"
+  echo "  In the R2 dashboard, click 'Create bucket'."
+  echo "  Suggested name pattern: pr-video-evidence-<your-github-username> (must be unique across your R2 account)."
+  read -p "  Bucket name you created: " R2_BUCKET
+  export R2_BUCKET
+  echo ""
+
+  blue "Step 3/5: Enable public access (so PR video links load)"
+  echo "  Open the bucket -> Settings -> Public access -> Allow Access -> confirm."
+  echo "  Cloudflare shows a public URL like  https://pub-<hash>.r2.dev  - copy it."
+  echo "  (Or configure a custom domain if you already have one; either works.)"
+  read -p "  Public base URL (e.g. https://pub-xxxx.r2.dev  OR  https://cdn.yourdomain.com): " R2_PUBLIC_BASE
+  export R2_PUBLIC_BASE
+  echo ""
+
+  blue "Step 4/5: Cloudflare Account ID"
+  echo "  In the Cloudflare dashboard, look at the right sidebar - 'Account ID'. Copy it."
+  read -p "  Cloudflare Account ID: " R2_ACCOUNT_ID
+  export R2_ACCOUNT_ID
+  echo ""
+
+  blue "Step 5/5: R2 API token (Access Key + Secret)"
+  echo "  URL: https://dash.cloudflare.com/?to=/:account/r2/api-tokens -> 'Create API token'."
+  echo "  Permissions: 'Object Read & Write'."
+  echo "  Scope: 'Apply to specific buckets only' -> pick '$R2_BUCKET'."
+  echo "  After creating, Cloudflare shows the Access Key ID + Secret Access Key ONCE. Copy both."
+  read -p "  R2 Access Key ID: " R2_ACCESS_KEY_ID
+  read -s -p "  R2 Secret Access Key (hidden): " R2_SECRET_ACCESS_KEY
+  echo ""
+  export R2_ACCESS_KEY_ID R2_SECRET_ACCESS_KEY
+  echo ""
+fi
+
+# Test upload with a tiny dummy file
+blue "Testing an actual upload to verify all four values..."
+tmp=$(mktemp -t fvd-r2-test.XXXXXX)
+echo "fix-video-evidence R2 test $(date -u +%FT%TZ)" > "$tmp"
+
+if bash "$here/upload-r2.sh" "$tmp" "_setup-check.txt" >/dev/null 2>&1; then
+  green "OK - test upload succeeded. R2 is wired up correctly."
+else
+  red "FAIL - test upload failed. One of the env vars is wrong. Re-run this wizard, or check upload-r2.sh output:"
+  echo ""
+  bash "$here/upload-r2.sh" "$tmp" "_setup-check.txt" || true
+  rm -f "$tmp"
+  exit 1
+fi
+rm -f "$tmp"
+echo ""
+
+# Print exports for shell profile
+blue "Add these lines to your shell profile (~/.zshrc or ~/.bashrc) so R2 is on for all future sessions:"
+cat <<EOF
+
+# fix-video-evidence - auto-upload PR videos to R2
+export PR_VIDEO_UPLOAD=r2
+export R2_BUCKET="$R2_BUCKET"
+export R2_ACCOUNT_ID="$R2_ACCOUNT_ID"
+export R2_ACCESS_KEY_ID="$R2_ACCESS_KEY_ID"
+export R2_SECRET_ACCESS_KEY="$R2_SECRET_ACCESS_KEY"
+EOF
+
+if [ -n "${R2_PUBLIC_BASE:-}" ]; then
+  echo "export R2_PUBLIC_BASE=\"$R2_PUBLIC_BASE\""
+fi
+
+echo ""
+green "Done. Copy the block above into your shell profile, then reload (source ~/.zshrc)."
+gray "From here on, every fix-video-evidence run auto-uploads the .webm files and inlines a video-tag link in the PR body. No drag-drop."

--- a/fix-video-evidence/reference/upload-r2.sh
+++ b/fix-video-evidence/reference/upload-r2.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# fix-video-evidence — upload one .webm to a Cloudflare R2 bucket via the S3-compatible API.
+#
+# Portable: reads bucket/creds from env only. NEVER hardcodes a bucket name.
+#
+# Required env:
+#   R2_BUCKET             the R2 bucket name
+#   R2_ACCOUNT_ID         Cloudflare account id (for the R2 S3 endpoint)
+#   R2_ACCESS_KEY_ID      R2 access key
+#   R2_SECRET_ACCESS_KEY  R2 secret
+# Optional:
+#   R2_PUBLIC_BASE        public URL prefix for the uploaded object.
+#                         If unset, prints the r2.dev URL (works only if the bucket
+#                         has public dev access enabled). Set this to your CDN.
+#
+# Usage:  upload-r2.sh <local-file> <object-key>
+# Echoes: the public URL for the uploaded object (stdout, one line).
+
+set -euo pipefail
+
+file="${1:?missing local file path}"
+key="${2:?missing object key (e.g. pr-evidence/repo-42-before.webm)}"
+
+for var in R2_BUCKET R2_ACCOUNT_ID R2_ACCESS_KEY_ID R2_SECRET_ACCESS_KEY; do
+  if [ -z "${!var:-}" ]; then
+    echo "upload-r2.sh: missing env $var" >&2
+    exit 2
+  fi
+done
+
+if ! command -v aws >/dev/null 2>&1; then
+  echo "upload-r2.sh: aws CLI not found — install with 'brew install awscli' (or use 'wrangler r2 object put' instead)" >&2
+  exit 3
+fi
+
+if [ ! -f "$file" ]; then
+  echo "upload-r2.sh: file not found: $file" >&2
+  exit 4
+fi
+
+endpoint="https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
+
+AWS_ACCESS_KEY_ID="$R2_ACCESS_KEY_ID" \
+AWS_SECRET_ACCESS_KEY="$R2_SECRET_ACCESS_KEY" \
+AWS_DEFAULT_REGION=auto \
+aws s3 cp "$file" "s3://${R2_BUCKET}/${key}" \
+  --endpoint-url "$endpoint" \
+  --content-type video/webm \
+  --only-show-errors >&2
+
+if [ -n "${R2_PUBLIC_BASE:-}" ]; then
+  echo "${R2_PUBLIC_BASE%/}/${key}"
+else
+  # Bucket-level r2.dev URL. Works only if public dev access is on for the bucket.
+  # Real deployments should set R2_PUBLIC_BASE to a CDN hostname.
+  echo "https://pub-${R2_ACCOUNT_ID}.r2.dev/${key}"
+fi


### PR DESCRIPTION
Adds a new skill `fix-video-evidence` that records the before/after of a bug-fix cycle as two `.webm` videos using Playwright's built-in `recordVideo`, then attaches them to the PR.

## Why a separate skill from evidence-driven-testing

`evidence-driven-testing` (already in this repo) is a heavier general-purpose evidence recorder - computer-use driver, Python + FFmpeg dependency, annotation timestamps, MP4 output, `report.md` + `manifest.json`. Great when you need all of that.

`fix-video-evidence` is the lighter, Playwright-only take on the narrower "record the before, apply the fix, record the after, attach both" workflow. No Python. No FFmpeg. No computer-use. Just Playwright's built-in `recordVideo`, a two-phase discipline (`PHASE=before|after` flips only the assertion), and a shell helper that either prints a drag-drop recipe (default) or auto-uploads to R2 (opt-in).

The two skills are complementary. `evidence-driven-testing` is right for full UI test flows with annotations; this one is right for the specific two-run cycle when Playwright is already available.

## What's in the PR

- `fix-video-evidence/SKILL.md` - agent instructions (prereqs, 6 steps, gotchas, verification checklist)
- `fix-video-evidence/reference/playwright-template.mjs` - one-script-two-phases template
- `fix-video-evidence/reference/attach-to-pr.sh` - portable-mode drag-drop recipe OR R2 auto-upload dispatcher
- `fix-video-evidence/reference/upload-r2.sh` - S3-compatible R2 upload (env-only config, no bucket hardcoded)
- `fix-video-evidence/reference/setup-r2.sh` - guided one-time R2 setup wizard (opens CF dashboard, walks through signup + bucket + token, tests an actual upload)
- Entry added to README.md `## Available skills` between `evidence-driven-testing` and `greploop`

## Not shipped (deliberate)

- Auto-captions (would need FFmpeg)
- Side-by-side single-video composite (would need FFmpeg)
- Hosted-service fallback for users without R2 (portable mode IS that fallback)

## Origin

Built for a personal portfolio project (github.com/Godslove-BA/shift-dashboard, a triage dashboard for PRs opened by autonomous overnight agents), then folded here because it seemed like a general-purpose addition to the software-factory pattern this repo teaches. Happy to iterate on framing/scope if you'd prefer a different positioning against `evidence-driven-testing` (e.g. renaming, merging concepts, etc.).

## License

MIT (matches this repo's convention).